### PR TITLE
Add admin dashboard layout

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,8 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import tailwind from '@tailwindcss/vite';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  vite: { plugins: [tailwind({ configFile: './tailwind.config.cjs' })] },
+});

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -1,4 +1,12 @@
-@import "tailwindcss";
-@plugin "daisyui"{
-  themes: light --default, dark --prefersdark;
-};
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html,
+body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  font-family: "InterVariable", "Noto Sans JP", system-ui, sans-serif;
+  line-height: 1.6;
+}

--- a/src/components/Chart.astro
+++ b/src/components/Chart.astro
@@ -1,0 +1,3 @@
+<div class="bg-base-200 rounded-box h-48 flex items-center justify-center">
+  Chart
+</div>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,0 +1,34 @@
+---
+import "../assets/app.css";
+---
+<div class="drawer lg:drawer-open">
+  <input id="admin-drawer" type="checkbox" class="drawer-toggle" />
+  <div class="drawer-content flex flex-col">
+    <nav class="navbar bg-base-100 border-b">
+      <div class="flex-none lg:hidden">
+        <label for="admin-drawer" class="btn btn-square btn-ghost" aria-label="open sidebar">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+        </label>
+      </div>
+      <div class="flex-1 px-2 text-xl font-bold">Admin Panel</div>
+      <div class="flex-none">
+        <button class="btn btn-ghost btn-circle" aria-label="user menu">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A4 4 0 0112 15a4 4 0 016.879 2.804M15 11a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+        </button>
+      </div>
+    </nav>
+    <main class="p-4 flex-1 overflow-y-auto">
+      <slot />
+    </main>
+  </div>
+  <div class="drawer-side">
+    <label for="admin-drawer" class="drawer-overlay" aria-label="close sidebar"></label>
+    <aside class="w-60 bg-base-200">
+      <ul class="menu p-4 min-h-full">
+        <li><a href="/admin" class="font-semibold">Dashboard</a></li>
+        <li><a href="#">Users</a></li>
+        <li><a href="#">Settings</a></li>
+      </ul>
+    </aside>
+  </div>
+</div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,24 +2,18 @@
 import "../assets/app.css";
 ---
 <!doctype html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
-	</head>
-	<body>
-		<slot />
-	</body>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <meta name="generator" content={Astro.generator} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+  <title>Admin Template</title>
+</head>
+<body class="min-h-screen">
+  <slot />
+</body>
 </html>
-
-<style>
-	html,
-	body {
-		margin: 0;
-		width: 100%;
-		height: 100%;
-	}
-</style>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,70 @@
+---
+import AdminLayout from '../../layouts/AdminLayout.astro';
+import Chart from '../../components/Chart.astro';
+
+interface Stat {
+  label: string;
+  value: string;
+}
+
+interface Order {
+  id: string;
+  status: string;
+  total: string;
+}
+
+const stats: Stat[] = [
+  { label: 'Users', value: '1,234' },
+  { label: 'Revenue', value: '$56k' },
+  { label: 'Orders', value: '890' },
+];
+
+const orders: Order[] = [
+  { id: '#1001', status: 'Processing', total: '$120' },
+  { id: '#1002', status: 'Shipped', total: '$86' },
+  { id: '#1003', status: 'Delivered', total: '$42' },
+];
+---
+
+<AdminLayout>
+  <div class="grid gap-4 lg:grid-cols-3">
+    <div class="space-y-4 lg:col-span-1">
+      {stats.map((s) => (
+        <div class="stats bg-base-100 shadow" aria-label={s.label}>
+          <div class="stat">
+            <div class="stat-title">{s.label}</div>
+            <div class="stat-value">{s.value}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+    <div class="lg:col-span-2">
+      <Chart />
+    </div>
+  </div>
+  <div class="mt-4 card bg-base-100 shadow">
+    <div class="card-body">
+      <h2 class="card-title">Recent Orders</h2>
+      <div class="overflow-x-auto">
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Order</th>
+              <th>Status</th>
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.map((o) => (
+              <tr>
+                <td>{o.id}</td>
+                <td>{o.status}</td>
+                <td>{o.total}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</AdminLayout>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['InterVariable', 'Noto Sans JP', 'system-ui', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [require('daisyui')],
+  daisyui: { themes: ['light', 'dark'] },
+};


### PR DESCRIPTION
## Summary
- refine base layout with min-height
- redesign AdminLayout with sidebar drawer and top navbar
- restructure dashboard page with stats grid, chart, and table

## Testing
- `pnpm build`
